### PR TITLE
Fix autoscale_handling lambda source_code_hash.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,9 +103,10 @@ data "aws_iam_policy_document" "lifecycle_policy" {
 }
 
 data "archive_file" "autoscale" {
-  type        = "zip"
-  source_dir  = "${path.module}/lambda/cleanup"
-  output_path = "${path.module}/lambda/cleanup/cleanup.zip"
+  type             = "zip"
+  source_dir       = "${path.module}/lambda/cleanup"
+  output_path      = "${path.module}/lambda/cleanup_zip/cleanup.zip"
+  output_file_mode = "0666"
 }
 
 resource "aws_lambda_function" "autoscale_handling" {


### PR DESCRIPTION
In the current configuration, each terraform run performs a lambda function deploy with a new sha256sum value